### PR TITLE
Remove syntax warnings, reformatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# VS Code
+.vscode/

--- a/uv_squares.py
+++ b/uv_squares.py
@@ -41,7 +41,6 @@ precision = 3
 def main(context, operator, square=False, snap_to_closest=False):
     if context.scene.tool_settings.use_uv_select_sync:
         operator.report({'ERROR'}, "Please disable 'Keep UV and edit mesh in sync'")
-        # context.scene.tool_settings.use_uv_select_sync = False
         return
 
     selected_objects = context.selected_objects
@@ -56,7 +55,6 @@ def main(context, operator, square=False, snap_to_closest=False):
 def main1(obj, context, operator, square, snap_to_closest):
     if context.scene.tool_settings.use_uv_select_sync:
         operator.report({'ERROR'}, "Please disable 'Keep UV and edit mesh in sync'")
-        # context.scene.tool_settings.use_uv_select_sync = False
         return
 
     start_time = timer()
@@ -129,12 +127,12 @@ def main1(obj, context, operator, square, snap_to_closest):
     islands = get_islands_from_selected_faces(sel_faces)
 
     def main2(target_face, faces):
-        shape_face(uv_layer, operator, target_face, verts_dict, square)
+        shape_face(uv_layer, target_face, verts_dict, square)
 
         if square:
-            follow_active_uv(operator, me, target_face, faces, 'EVEN')
+            follow_active_uv(me, target_face, faces, 'EVEN')
         else:
-            follow_active_uv(operator, me, target_face, faces)
+            follow_active_uv(me, target_face, faces)
 
     for island in islands:
         target_face = bm.faces.active
@@ -158,15 +156,7 @@ def main1(obj, context, operator, square, snap_to_closest):
     return success_finished(me, start_time)
 
 
-'''def ScaleSelection(factor, pivot = 'CURSOR'):
-    last_pivot = bpy.context.space_data.pivot_point
-    bpy.context.space_data.pivot_point = pivot
-    bpy.ops.transform.resize(value=(factor, factor, factor), constraint_axis=(False, False, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
-    bpy.context.space_data.pivot_point = last_pivot
-    return'''
-
-
-def shape_face(uv_layer, operator, target_face, verts_dict, square):
+def shape_face(uv_layer, target_face, verts_dict, square):
     corners = []
     for l in target_face.loops:
         luv = l[uv_layer]
@@ -322,7 +312,7 @@ def list_quasi_contains_vect(list, vect):
 
 
 # modified ideasman42's uvcalc_follow_active.py
-def follow_active_uv(operator, me, f_act, faces, extend_mode='LENGTH_AVERAGE'):
+def follow_active_uv(me, f_act, faces, extend_mode='LENGTH_AVERAGE'):
     bm = bmesh.from_edit_mesh(me)
     uv_act = bm.loops.layers.uv.active
 
@@ -497,21 +487,10 @@ def follow_active_uv(operator, me, f_act, faces, extend_mode='LENGTH_AVERAGE'):
 
 
 def success_finished(me, start_time):
-    # use for backtrack of steps
-    # bpy.ops.ed.undo_push()
     bmesh.update_edit_mesh(me)
     elapsed = round(timer() - start_time, 2)
-    # if (elapsed >= 0.05): operator.report({'INFO'}, "UvSquares finished, elapsed:", elapsed, "s.")
     if elapsed >= 0.05:
         print("UvSquares finished, elapsed:", elapsed, "s.")
-
-
-'''def SymmetrySelected(axis, pivot = "MEDIAN"):
-    last_pivot = bpy.context.space_data.pivot_point
-    bpy.context.space_data.pivot_point = pivot
-    bpy.ops.transform.mirror(constraint_axis=(True, False, False), constraint_orientation='GLOBAL', proportional_edit_falloff='SMOOTH', proportional_size=1)
-    bpy.context.space_data.pivot_point = last_pivot
-    return'''
 
 
 def are_vects_lined_on_axis(verts):
@@ -737,34 +716,13 @@ def set_all_2d_cursors_to(x, y):
     bpy.context.area.type = last_area
 
 
-'''def RotateSelected(angle, pivot = None):
-    if pivot is None:
-        pivot = "MEDIAN"
-   
-    last_area = bpy.context.area.type
-    bpy.context.area.type = 'IMAGE_EDITOR'
-    
-    last_pivot = bpy.context.space_data.pivot_point
-    bpy.context.space_data.pivot_point = pivot
-    
-    for area in bpy.context.screen.areas:
-        if area.type == 'IMAGE_EDITOR':
-            bpy.ops.transform.rotate(value=radians(angle), axis=(-0, -0, -1), constraint_axis=(False, False, False), constraint_orientation='LOCAL', mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
-            break
-
-    bpy.context.space_data.pivot_point = last_pivot
-    bpy.context.area.type = last_area
-    
-    return'''
-
-
 def are_verts_quasi_equal(v1, v2, allowed_error=0.00001):
     if abs(v1.uv.x - v2.uv.x) < allowed_error and abs(v1.uv.y - v2.uv.y) < allowed_error:
         return True
     return False
 
 
-def rip_uv_faces(context, operator):
+def rip_uv_faces(context,):
     start_time = timer()
 
     obj = context.active_object
@@ -907,7 +865,7 @@ class UV_PT_RipFaces(bpy.types.Operator):
         return (context.mode == 'EDIT_MESH')
 
     def execute(self, context):
-        rip_uv_faces(context, self)
+        rip_uv_faces(context)
         return {'FINISHED'}
 
 

--- a/uv_squares.py
+++ b/uv_squares.py
@@ -32,12 +32,13 @@ from timeit import default_timer as timer
 
 precision = 3
 
-#todo: make joining radius scale with editor zoom rate or average unit length
-#todo: align to axis by respect to vert distance
-#todo: snap 2dCursor to closest selected vert (when more vertices are selected
-#todo: rip different vertex on each press
 
-def main(context, operator, square = False, snapToClosest = False):
+# todo: make joining radius scale with editor zoom rate or average unit length
+# todo: align to axis by respect to vert distance
+# todo: snap 2dCursor to closest selected vert (when more vertices are selected
+# todo: rip different vertex on each press
+
+def main(context, operator, square=False, snapToClosest=False):
     if context.scene.tool_settings.use_uv_select_sync:
         operator.report({'ERROR'}, "Please disable 'Keep UV and edit mesh in sync'")
         # context.scene.tool_settings.use_uv_select_sync = False
@@ -50,6 +51,7 @@ def main(context, operator, square = False, snapToClosest = False):
     for obj in selected_objects:
         if (obj.type == "MESH"):
             main1(obj, context, operator, square, snapToClosest)
+
 
 def main1(obj, context, operator, square, snapToClosest):
     if context.scene.tool_settings.use_uv_select_sync:
@@ -71,7 +73,7 @@ def main1(obj, context, operator, square, snapToClosest):
         return
 
     cursorClosestTo = CursorClosestTo(filteredVerts)
-    #line is selected
+    # line is selected
 
     if len(selFaces) == 0:
         if snapToClosest:
@@ -117,7 +119,7 @@ def main1(obj, context, operator, square, snapToClosest):
     def getIslandsFromSelectedFaces(selectedFaces):
         islands = []
         toCheck = set(selectedFaces)
-        while(len(toCheck)):
+        while (len(toCheck)):
             face = toCheck.pop()
             island = getIslandFromFace(face)
             islands.append(island)
@@ -126,25 +128,27 @@ def main1(obj, context, operator, square, snapToClosest):
 
     islands = getIslandsFromSelectedFaces(selFaces)
 
-    def main2 (targetFace, faces):
+    def main2(targetFace, faces):
         ShapeFace(uv_layer, operator, targetFace, vertsDict, square)
 
-        if square: FollowActiveUV(operator, me, targetFace, faces, 'EVEN')
-        else: FollowActiveUV(operator, me, targetFace, faces)
+        if square:
+            FollowActiveUV(operator, me, targetFace, faces, 'EVEN')
+        else:
+            FollowActiveUV(operator, me, targetFace, faces)
 
     for island in islands:
         targetFace = bm.faces.active
         if (targetFace is None or
-            targetFace not in island or
-            len(islands) > 1 or
-            not targetFace.select or
-            len(targetFace.verts) != 4):
-                targetFace = next(iter(island))
+                targetFace not in island or
+                len(islands) > 1 or
+                not targetFace.select or
+                len(targetFace.verts) != 4):
+            targetFace = next(iter(island))
 
         main2(targetFace, island)
 
     if noEdge is False:
-        #edge has ripped so we connect it back
+        # edge has ripped so we connect it back
         for ev in edgeVerts:
             key = (round(ev.uv.x, precision), round(ev.uv.y, precision))
             if key in vertsDict:
@@ -153,12 +157,14 @@ def main1(obj, context, operator, square, snapToClosest):
 
     return SuccessFinished(me, startTime)
 
+
 '''def ScaleSelection(factor, pivot = 'CURSOR'):
     last_pivot = bpy.context.space_data.pivot_point
     bpy.context.space_data.pivot_point = pivot
     bpy.ops.transform.resize(value=(factor, factor, factor), constraint_axis=(False, False, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.context.space_data.pivot_point = last_pivot
     return'''
+
 
 def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
     corners = []
@@ -167,7 +173,7 @@ def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
         corners.append(luv)
 
     if len(corners) != 4:
-        #operator.report({'ERROR'}, "bla")
+        # operator.report({'ERROR'}, "bla")
         return
 
     lucv, ldcv, rucv, rdcv = Corners(corners)
@@ -176,15 +182,20 @@ def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
     MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, cct, square)
 
 
-def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square = False):
+def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square=False):
     sizeX, sizeY = ImageSize()
-    ratio = sizeX/sizeY
+    ratio = sizeX / sizeY
 
-    if startv is None: startv = lucv.uv
-    elif AreVertsQuasiEqual(startv, rucv): startv = rucv.uv
-    elif AreVertsQuasiEqual(startv, rdcv): startv = rdcv.uv
-    elif AreVertsQuasiEqual(startv, ldcv): startv = ldcv.uv
-    else: startv = lucv.uv
+    if startv is None:
+        startv = lucv.uv
+    elif AreVertsQuasiEqual(startv, rucv):
+        startv = rucv.uv
+    elif AreVertsQuasiEqual(startv, rdcv):
+        startv = rdcv.uv
+    elif AreVertsQuasiEqual(startv, ldcv):
+        startv = ldcv.uv
+    else:
+        startv = lucv.uv
 
     lucv = lucv.uv
     rucv = rucv.uv
@@ -213,38 +224,38 @@ def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square =
         finalScaleX = hypotVert(ldcv, rdcv)
         finalScaleY = hypotVert(ldcv, lucv)
         currRowX = ldcv.x
-        currRowY = ldcv.y +finalScaleY
+        currRowY = ldcv.y + finalScaleY
 
-    if square: finalScaleY = finalScaleX*ratio
-    #lucv, rucv
+    if square: finalScaleY = finalScaleX * ratio
+    # lucv, rucv
     x = round(lucv.x, precision)
     y = round(lucv.y, precision)
-    for v in vertsDict[(x,y)]:
+    for v in vertsDict[(x, y)]:
         v.uv.x = currRowX
         v.uv.y = currRowY
 
     x = round(rucv.x, precision)
     y = round(rucv.y, precision)
-    for v in vertsDict[(x,y)]:
+    for v in vertsDict[(x, y)]:
         v.uv.x = currRowX + finalScaleX
         v.uv.y = currRowY
 
-    #rdcv, ldcv
+    # rdcv, ldcv
     x = round(rdcv.x, precision)
     y = round(rdcv.y, precision)
-    for v in vertsDict[(x,y)]:
+    for v in vertsDict[(x, y)]:
         v.uv.x = currRowX + finalScaleX
         v.uv.y = currRowY - finalScaleY
 
     x = round(ldcv.x, precision)
     y = round(ldcv.y, precision)
-    for v in vertsDict[(x,y)]:
+    for v in vertsDict[(x, y)]:
         v.uv.x = currRowX
         v.uv.y = currRowY - finalScaleY
 
 
 def SnapCursorToClosestSelected(filteredVerts):
-    #TODO: snap to closest selected
+    # TODO: snap to closest selected
     if len(filteredVerts) == 1:
         SetAll2dCursorsTo(filteredVerts[0].uv.x, filteredVerts[0].uv.y)
 
@@ -255,7 +266,7 @@ def ListsOfVerts(uv_layer, bm):
     filteredVerts = []
     selFaces = []
     nonQuadFaces = []
-    vertsDict = defaultdict(list)                #dict
+    vertsDict = defaultdict(list)  # dict
 
     for f in bm.faces:
         isFaceSel = True
@@ -263,12 +274,13 @@ def ListsOfVerts(uv_layer, bm):
         if (f.select == False):
             continue
 
-        #collect edge verts if any
+        # collect edge verts if any
         for l in f.loops:
             luv = l[uv_layer]
             if luv.select is True:
                 facesEdgeVerts.append(luv)
-            else: isFaceSel = False
+            else:
+                isFaceSel = False
 
         allEdgeVerts.extend(facesEdgeVerts)
         if isFaceSel:
@@ -284,7 +296,8 @@ def ListsOfVerts(uv_layer, bm):
                     y = round(luv.uv.y, precision)
                     vertsDict[(x, y)].append(luv)
 
-        else: edgeVerts.extend(facesEdgeVerts)
+        else:
+            edgeVerts.extend(facesEdgeVerts)
 
     noEdge = False
     if len(edgeVerts) == 0:
@@ -295,9 +308,11 @@ def ListsOfVerts(uv_layer, bm):
         for ev in edgeVerts:
             if ListQuasiContainsVect(filteredVerts, ev) is False:
                 filteredVerts.append(ev)
-    else: filteredVerts = edgeVerts
+    else:
+        filteredVerts = edgeVerts
 
     return edgeVerts, filteredVerts, selFaces, nonQuadFaces, vertsDict, noEdge
+
 
 def ListQuasiContainsVect(list, vect):
     for v in list:
@@ -305,8 +320,9 @@ def ListQuasiContainsVect(list, vect):
             return True
     return False
 
-#modified ideasman42's uvcalc_follow_active.py
-def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE = 'LENGTH_AVERAGE'):
+
+# modified ideasman42's uvcalc_follow_active.py
+def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE='LENGTH_AVERAGE'):
     bm = bmesh.from_edit_mesh(me)
     uv_act = bm.loops.layers.uv.active
 
@@ -442,7 +458,7 @@ def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE = 'LENGTH_AVERAGE'):
 
     if EXTEND_MODE == 'LENGTH_AVERAGE':
         bm.edges.index_update()
-        edge_lengths = [None] * len(bm.edges)   #NoneType times the length of edges list
+        edge_lengths = [None] * len(bm.edges)  # NoneType times the length of edges list
 
         for f in faces:
             # we know its a quad
@@ -476,15 +492,19 @@ def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE = 'LENGTH_AVERAGE'):
 
     bmesh.update_edit_mesh(me, loop_triangles=False)
 
+
 '''----------------------------------'''
 
+
 def SuccessFinished(me, startTime):
-    #use for backtrack of steps
-    #bpy.ops.ed.undo_push()
+    # use for backtrack of steps
+    # bpy.ops.ed.undo_push()
     bmesh.update_edit_mesh(me)
-    elapsed = round(timer()-startTime, 2)
-    #if (elapsed >= 0.05): operator.report({'INFO'}, "UvSquares finished, elapsed:", elapsed, "s.")
-    if (elapsed >= 0.05): print("UvSquares finished, elapsed:", elapsed, "s.")
+    elapsed = round(timer() - startTime, 2)
+    # if (elapsed >= 0.05): operator.report({'INFO'}, "UvSquares finished, elapsed:", elapsed, "s.")
+    if elapsed >= 0.05:
+        print("UvSquares finished, elapsed:", elapsed, "s.")
+
 
 '''def SymmetrySelected(axis, pivot = "MEDIAN"):
     last_pivot = bpy.context.space_data.pivot_point
@@ -492,6 +512,7 @@ def SuccessFinished(me, startTime):
     bpy.ops.transform.mirror(constraint_axis=(True, False, False), constraint_orientation='GLOBAL', proportional_edit_falloff='SMOOTH', proportional_size=1)
     bpy.context.space_data.pivot_point = last_pivot
     return'''
+
 
 def AreVectsLinedOnAxis(verts):
     areLinedX = True
@@ -506,17 +527,18 @@ def AreVectsLinedOnAxis(verts):
             areLinedY = False
     return areLinedX or areLinedY
 
-def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv = None):
+
+def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv=None):
     verts = filteredVerts
-    verts.sort(key=lambda x: x.uv[0])      #sort by .x
+    verts.sort(key=lambda x: x.uv[0])  # sort by .x
 
     first = verts[0].uv
-    last = verts[len(verts)-1].uv
+    last = verts[len(verts) - 1].uv
 
     horizontal = True
     if (last.x - first.x) > 0.00001:
-        slope = (last.y - first.y)/(last.x - first.x)
-        if (slope > 1) or (slope <-1):
+        slope = (last.y - first.y) / (last.x - first.x)
+        if (slope > 1) or (slope < -1):
             horizontal = False
     else:
         horizontal = False
@@ -531,12 +553,13 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv = None)
             currentX = first.x
             currentY = first.y
     else:
-        verts.sort(key=lambda x: x.uv[1])  #sort by .y
-        verts.reverse()     #reverse because y values drop from up to down
+        verts.sort(key=lambda x: x.uv[1])  # sort by .y
+        verts.reverse()  # reverse because y values drop from up to down
         first = verts[0].uv
-        last = verts[len(verts)-1].uv
+        last = verts[len(verts) - 1].uv
 
-        length = hypot(first.x - last.x, first.y - last.y)  # we have to call length here because if it is not Hor first and second can not actually be first and second
+        length = hypot(first.x - last.x,
+                       first.y - last.y)  # we have to call length here because if it is not Hor first and second can not actually be first and second
 
         if startv is last:
             currentX = last.x
@@ -547,7 +570,7 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv = None)
             currentY = first.y
 
     numberOfVerts = len(verts)
-    finalScale = length / (numberOfVerts-1)
+    finalScale = length / (numberOfVerts - 1)
 
     if horizontal is True:
         for v in verts:
@@ -555,7 +578,7 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv = None)
             x = round(v.x, precision)
             y = round(v.y, precision)
 
-            for vert in vertsDict[(x,y)]:
+            for vert in vertsDict[(x, y)]:
                 vert.uv.x = currentX
                 vert.uv.y = currentY
 
@@ -565,35 +588,36 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv = None)
             x = round(v.uv.x, precision)
             y = round(v.uv.y, precision)
 
-            for vert in vertsDict[(x,y)]:
+            for vert in vertsDict[(x, y)]:
                 vert.uv.x = currentX
                 vert.uv.y = currentY
 
             currentY = currentY - finalScale
 
+
 def VertsDictForLine(uv_layer, bm, vertsDict):
     for f in bm.faces:
         for l in f.loops:
-                luv = l[uv_layer]
-                if luv.select is True:
-                    x = round(luv.uv.x, precision)
-                    y = round(luv.uv.y, precision)
+            luv = l[uv_layer]
+            if luv.select is True:
+                x = round(luv.uv.x, precision)
+                y = round(luv.uv.y, precision)
 
-                    vertsDict[(x, y)].append(luv)
+                vertsDict[(x, y)].append(luv)
 
-def ScaleTo0OnAxisAndCursor(filteredVerts, startv = None, horizontal = None):
 
+def ScaleTo0OnAxisAndCursor(filteredVerts, startv=None, horizontal=None):
     verts = filteredVerts
-    verts.sort(key=lambda x: x.uv[0])      #sort by .x
+    verts.sort(key=lambda x: x.uv[0])  # sort by .x
 
     first = verts[0]
-    last = verts[len(verts)-1]
+    last = verts[len(verts) - 1]
 
     if horizontal is None:
         horizontal = True
-        if ((last.uv.x - first.uv.x) >0.00001):
-            slope = (last.uv.y - first.uv.y)/(last.uv.x - first.uv.x)
-            if (slope > 1) or (slope <-1):
+        if ((last.uv.x - first.uv.x) > 0.00001):
+            slope = (last.uv.y - first.uv.y) / (last.uv.x - first.uv.x)
+            if (slope > 1) or (slope < -1):
                 horizontal = False
         else:
             horizontal = False
@@ -603,20 +627,21 @@ def ScaleTo0OnAxisAndCursor(filteredVerts, startv = None, horizontal = None):
             startv = first
 
         SetAll2dCursorsTo(startv.uv.x, startv.uv.y)
-        #scale to 0 on Y
+        # scale to 0 on Y
         ScaleTo0('Y')
 
     else:
-        verts.sort(key=lambda x: x.uv[1])  #sort by .y
-        verts.reverse()     #reverse because y values drop from up to down
+        verts.sort(key=lambda x: x.uv[1])  # sort by .y
+        verts.reverse()  # reverse because y values drop from up to down
         first = verts[0]
 
         if startv is None:
             startv = first
 
         SetAll2dCursorsTo(startv.uv.x, startv.uv.y)
-        #scale to 0 on X
+        # scale to 0 on X
         ScaleTo0('X')
+
 
 def ScaleTo0(axis):
     last_area = bpy.context.area.type
@@ -627,10 +652,11 @@ def ScaleTo0(axis):
     for area in bpy.context.screen.areas:
         if area.type == 'IMAGE_EDITOR':
             if axis == 'Y':
-                bpy.ops.transform.resize(value=(1, 0, 1), constraint_axis=(False, True, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
+                bpy.ops.transform.resize(value=(1, 0, 1), constraint_axis=(False, True, False), mirror=False,
+                                         proportional_edit_falloff='SMOOTH', proportional_size=1)
             else:
-                bpy.ops.transform.resize(value=(0, 1, 1), constraint_axis=(True, False, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
-
+                bpy.ops.transform.resize(value=(0, 1, 1), constraint_axis=(True, False, False), mirror=False,
+                                         proportional_edit_falloff='SMOOTH', proportional_size=1)
 
     bpy.context.space_data.pivot_point = last_pivot
 
@@ -638,6 +664,7 @@ def ScaleTo0(axis):
 def hypotVert(v1, v2):
     hyp = hypot(v1.x - v2.x, v1.y - v2.y)
     return hyp
+
 
 def Corners(corners):
     firstHighest = corners[0]
@@ -671,8 +698,9 @@ def Corners(corners):
 
     return leftUp, leftDown, rightUp, rightDown
 
+
 def ImageSize():
-    ratioX, ratioY = 256,256
+    ratioX, ratioY = 256, 256
     for a in bpy.context.screen.areas:
         if a.type == 'IMAGE_EDITOR':
             img = a.spaces[0].image
@@ -681,10 +709,11 @@ def ImageSize():
             break
     return ratioX, ratioY
 
+
 def CursorClosestTo(verts):
     sizeX, sizeY = ImageSize()
     if bpy.app.version >= (2, 80, 0):
-        sizeX, sizeY = 1,1
+        sizeX, sizeY = 1, 1
     min = float('inf')
     minV = verts[0]
     for v in verts:
@@ -692,13 +721,14 @@ def CursorClosestTo(verts):
         for area in bpy.context.screen.areas:
             if area.type == 'IMAGE_EDITOR':
                 loc = area.spaces[0].cursor_location
-                hyp = hypot(loc.x/sizeX -v.uv.x, loc.y/sizeY -v.uv.y)
+                hyp = hypot(loc.x / sizeX - v.uv.x, loc.y / sizeY - v.uv.y)
                 if (hyp < min):
                     min = hyp
                     minV = v
     return minV
 
-def SetAll2dCursorsTo(x,y):
+
+def SetAll2dCursorsTo(x, y):
     last_area = bpy.context.area.type
     bpy.context.area.type = 'IMAGE_EDITOR'
 
@@ -706,6 +736,7 @@ def SetAll2dCursorsTo(x,y):
 
     bpy.context.area.type = last_area
     return
+
 
 '''def RotateSelected(angle, pivot = None):
     if pivot is None:
@@ -727,10 +758,12 @@ def SetAll2dCursorsTo(x,y):
     
     return'''
 
-def AreVertsQuasiEqual(v1, v2, allowedError = 0.00001):
-    if abs(v1.uv.x -v2.uv.x) < allowedError and abs(v1.uv.y -v2.uv.y) < allowedError:
+
+def AreVertsQuasiEqual(v1, v2, allowedError=0.00001):
+    if abs(v1.uv.x - v2.uv.x) < allowedError and abs(v1.uv.y - v2.uv.y) < allowedError:
         return True
     return False
+
 
 def RipUvFaces(context, operator):
     startTime = timer()
@@ -782,6 +815,7 @@ def RipUvFaces(context, operator):
 
     return SuccessFinished(me, startTime)
 
+
 def JoinUvFaces(context):
     startTime = timer()
 
@@ -792,18 +826,18 @@ def JoinUvFaces(context):
     uv_layer = bm.loops.layers.uv.verify()
     # bm.faces.layers.tex.verify()  # currently blender needs both layers.
 
-    vertsDict = defaultdict(list)        #dict
+    vertsDict = defaultdict(list)  # dict
 
-    #TODO: radius by image scale
+    # TODO: radius by image scale
     radius = 0.002
 
     for f in bm.faces:
         for l in f.loops:
-           luv = l[uv_layer]
-           if luv.select is True:
-               x = round(luv.uv.x, precision)
-               y = round(luv.uv.y, precision)
-               vertsDict[(x,y)].append(luv)
+            luv = l[uv_layer]
+            if luv.select is True:
+                x = round(luv.uv.x, precision)
+                y = round(luv.uv.y, precision)
+                vertsDict[(x, y)].append(luv)
 
     for key in vertsDict:
         min = 1
@@ -813,7 +847,8 @@ def JoinUvFaces(context):
             for l in f.loops:
                 luv = l[uv_layer]
                 if luv.select is False:
-                    hyp = hypot(vertsDict[(key[0], key[1])][0].uv.x -luv.uv.x, vertsDict[(key[0], key[1])][0].uv.y -luv.uv.y)
+                    hyp = hypot(vertsDict[(key[0], key[1])][0].uv.x - luv.uv.x,
+                                vertsDict[(key[0], key[1])][0].uv.y - luv.uv.y)
                     if (hyp <= min) and hyp < radius:
                         min = hyp
                         minV = luv
@@ -827,6 +862,7 @@ def JoinUvFaces(context):
 
     return SuccessFinished(me, startTime)
 
+
 def DeselectAll():
     bpy.ops.uv.select_all(action='DESELECT')
     return
@@ -837,6 +873,7 @@ class UV_PT_UvSquares(bpy.types.Operator):
     bl_idname = "uv.uv_squares"
     bl_label = "UVs to grid of squares"
     bl_options = {'REGISTER', 'UNDO'}
+
     @classmethod
     def poll(cls, context):
         return (context.mode == 'EDIT_MESH')
@@ -844,6 +881,7 @@ class UV_PT_UvSquares(bpy.types.Operator):
     def execute(self, context):
         main(context, self, True)
         return {'FINISHED'}
+
 
 class UV_PT_UvSquaresByShape(bpy.types.Operator):
     """Reshapes UV faces to a grid with respect to shape by length of edges around selected corner"""
@@ -859,6 +897,7 @@ class UV_PT_UvSquaresByShape(bpy.types.Operator):
         main(context, self)
         return {'FINISHED'}
 
+
 class UV_PT_RipFaces(bpy.types.Operator):
     """Rip UV faces apart"""
     bl_idname = "uv.uv_face_rip"
@@ -872,6 +911,7 @@ class UV_PT_RipFaces(bpy.types.Operator):
     def execute(self, context):
         RipUvFaces(context, self)
         return {'FINISHED'}
+
 
 class UV_PT_JoinFaces(bpy.types.Operator):
     """Join selected UV faces to closest nonselected vertices"""
@@ -887,6 +927,7 @@ class UV_PT_JoinFaces(bpy.types.Operator):
         JoinUvFaces(context)
         return {'FINISHED'}
 
+
 class UV_PT_SnapToAxis(bpy.types.Operator):
     """Snap sequenced vertices to Axis"""
     bl_idname = "uv.uv_snap_to_axis"
@@ -900,6 +941,7 @@ class UV_PT_SnapToAxis(bpy.types.Operator):
     def execute(self, context):
         main(context, self)
         return {'FINISHED'}
+
 
 class UV_PT_SnapToAxisWithEqual(bpy.types.Operator):
     """Snap sequenced vertices to Axis with Equal Distance between"""
@@ -916,12 +958,21 @@ class UV_PT_SnapToAxisWithEqual(bpy.types.Operator):
         main(context, self)
         return {'FINISHED'}
 
+
 addon_keymaps = []
 
+
 def menu_func_uv_squares(self, context): self.layout.operator(UV_PT_UvSquares.bl_idname)
+
+
 def menu_func_uv_squares_by_shape(self, context): self.layout.operator(UV_PT_UvSquaresByShape.bl_idname)
+
+
 def menu_func_face_rip(self, context): self.layout.operator(UV_PT_RipFaces.bl_idname)
+
+
 def menu_func_face_join(self, context): self.layout.operator(UV_PT_JoinFaces.bl_idname)
+
 
 class UV_PT_UvSquaresPanel(bpy.types.Panel):
     """UvSquares Panel"""
@@ -937,15 +988,15 @@ class UV_PT_UvSquaresPanel(bpy.types.Panel):
         row.label(text="Select Sequenced Vertices to:")
         split = layout.split()
         col = split.column(align=True)
-        col.operator(UV_PT_SnapToAxis.bl_idname, text="Snap to Axis (X or Y)", icon = "ARROW_LEFTRIGHT")
-        col.operator(UV_PT_SnapToAxisWithEqual.bl_idname, text="Snap with Equal Distance", icon = "THREE_DOTS")
+        col.operator(UV_PT_SnapToAxis.bl_idname, text="Snap to Axis (X or Y)", icon="ARROW_LEFTRIGHT")
+        col.operator(UV_PT_SnapToAxisWithEqual.bl_idname, text="Snap with Equal Distance", icon="THREE_DOTS")
 
         row = layout.row()
         row.label(text="Convert \"Rectangle\" (4 corners):")
         split = layout.split()
         col = split.column(align=True)
-        col.operator(UV_PT_UvSquaresByShape.bl_idname, text="To Grid By Shape", icon = "UV_FACESEL")
-        col.operator(UV_PT_UvSquares.bl_idname, text="To Square Grid", icon = "GRID")
+        col.operator(UV_PT_UvSquaresByShape.bl_idname, text="To Grid By Shape", icon="UV_FACESEL")
+        col.operator(UV_PT_UvSquares.bl_idname, text="To Square Grid", icon="GRID")
 
         split = layout.split()
         col = split.column(align=True)
@@ -958,11 +1009,12 @@ class UV_PT_UvSquaresPanel(bpy.types.Panel):
         col = split.column(align=True)
         row = col.row(align=True)
 
-        row.operator(UV_PT_RipFaces.bl_idname, text="Rip Vertex", icon = "LAYER_ACTIVE")
-        row.operator(UV_PT_RipFaces.bl_idname, text="Rip Faces", icon = "UV_ISLANDSEL")
-        col.operator(UV_PT_JoinFaces.bl_idname, text="Snap to Closest Unselected", icon = "SNAP_GRID")
+        row.operator(UV_PT_RipFaces.bl_idname, text="Rip Vertex", icon="LAYER_ACTIVE")
+        row.operator(UV_PT_RipFaces.bl_idname, text="Rip Faces", icon="UV_ISLANDSEL")
+        col.operator(UV_PT_JoinFaces.bl_idname, text="Snap to Closest Unselected", icon="SNAP_GRID")
         row = layout.row()
         row.label(text="V - Join (Stitch), I -Toggle Islands")
+
 
 def register():
     bpy.utils.register_class(UV_PT_UvSquaresPanel)
@@ -973,13 +1025,13 @@ def register():
     bpy.utils.register_class(UV_PT_SnapToAxis)
     bpy.utils.register_class(UV_PT_SnapToAxisWithEqual)
 
-    #menu
+    # menu
     bpy.types.IMAGE_MT_uvs.append(menu_func_uv_squares)
     bpy.types.IMAGE_MT_uvs.append(menu_func_uv_squares_by_shape)
     bpy.types.IMAGE_MT_uvs.append(menu_func_face_rip)
     bpy.types.IMAGE_MT_uvs.append(menu_func_face_join)
 
-    #handle the keymap
+    # handle the keymap
     wm = bpy.context.window_manager
 
     if (wm.keyconfigs.addon):
@@ -994,6 +1046,7 @@ def register():
         km = wm.keyconfigs.addon.keymaps.new(name='UV Editor', space_type='EMPTY')
         kmi = km.keymap_items.new(UV_PT_JoinFaces.bl_idname, 'V', 'PRESS', alt=True, shift=True)
         addon_keymaps.append((km, kmi))
+
 
 def unregister():
     bpy.utils.unregister_class(UV_PT_UvSquaresPanel)
@@ -1014,6 +1067,7 @@ def unregister():
         km.keymap_items.remove(kmi)
     # clear the list
     addon_keymaps.clear()
+
 
 if __name__ == "__main__":
     register()

--- a/uv_squares.py
+++ b/uv_squares.py
@@ -45,11 +45,11 @@ def main(context, operator, square=False, snap_to_closest=False):
         return
 
     selected_objects = context.selected_objects
-    if (context.edit_object not in selected_objects):
+    if context.edit_object not in selected_objects:
         selected_objects.append(context.edit_object)
 
     for obj in selected_objects:
-        if (obj.type == "MESH"):
+        if obj.type == "MESH":
             main1(obj, context, operator, square, snap_to_closest)
 
 
@@ -1033,15 +1033,16 @@ def register():
     wm = bpy.context.window_manager
 
     if (wm.keyconfigs.addon):
-        km = wm.keyconfigs.addon.keymaps.new(name='UV Editor', space_type='EMPTY')
+        km_name = 'UV Editor'
+        km = wm.keyconfigs.addon.keymaps.new(name=km_name, space_type='EMPTY')
         kmi = km.keymap_items.new(UV_PT_UvSquaresByShape.bl_idname, 'E', 'PRESS', alt=True)
         addon_keymaps.append((km, kmi))
 
-        km = wm.keyconfigs.addon.keymaps.new(name='UV Editor', space_type='EMPTY')
+        km = wm.keyconfigs.addon.keymaps.new(name=km_name, space_type='EMPTY')
         kmi = km.keymap_items.new(UV_PT_RipFaces.bl_idname, 'V', 'PRESS', alt=True)
         addon_keymaps.append((km, kmi))
 
-        km = wm.keyconfigs.addon.keymaps.new(name='UV Editor', space_type='EMPTY')
+        km = wm.keyconfigs.addon.keymaps.new(name=km_name, space_type='EMPTY')
         kmi = km.keymap_items.new(UV_PT_JoinFaces.bl_idname, 'V', 'PRESS', alt=True, shift=True)
         addon_keymaps.append((km, kmi))
 

--- a/uv_squares.py
+++ b/uv_squares.py
@@ -38,7 +38,7 @@ precision = 3
 # todo: snap 2dCursor to closest selected vert (when more vertices are selected
 # todo: rip different vertex on each press
 
-def main(context, operator, square=False, snapToClosest=False):
+def main(context, operator, square=False, snap_to_closest=False):
     if context.scene.tool_settings.use_uv_select_sync:
         operator.report({'ERROR'}, "Please disable 'Keep UV and edit mesh in sync'")
         # context.scene.tool_settings.use_uv_select_sync = False
@@ -50,112 +50,112 @@ def main(context, operator, square=False, snapToClosest=False):
 
     for obj in selected_objects:
         if (obj.type == "MESH"):
-            main1(obj, context, operator, square, snapToClosest)
+            main1(obj, context, operator, square, snap_to_closest)
 
 
-def main1(obj, context, operator, square, snapToClosest):
+def main1(obj, context, operator, square, snap_to_closest):
     if context.scene.tool_settings.use_uv_select_sync:
         operator.report({'ERROR'}, "Please disable 'Keep UV and edit mesh in sync'")
         # context.scene.tool_settings.use_uv_select_sync = False
         return
 
-    startTime = timer()
+    start_time = timer()
     me = obj.data
     bm = bmesh.from_edit_mesh(me)
     uv_layer = bm.loops.layers.uv.verify()
     # bm.faces.layers.tex.verify()  # currently blender needs both layers.
 
-    edgeVerts, filteredVerts, selFaces, nonQuadFaces, vertsDict, noEdge = ListsOfVerts(uv_layer, bm)
+    edge_verts, filtered_verts, sel_faces, non_quad_faces, verts_dict, no_edge = lists_of_verts(uv_layer, bm)
 
-    if len(filteredVerts) == 0: return
-    if len(filteredVerts) == 1:
-        SnapCursorToClosestSelected(filteredVerts)
+    if len(filtered_verts) == 0: return
+    if len(filtered_verts) == 1:
+        snap_cursor_to_closest_selected(filtered_verts)
         return
 
-    cursorClosestTo = CursorClosestTo(filteredVerts)
+    cursor_closest_to = find_cursor_closest_to(filtered_verts)
     # line is selected
 
-    if len(selFaces) == 0:
-        if snapToClosest:
-            SnapCursorToClosestSelected(filteredVerts)
+    if len(sel_faces) == 0:
+        if snap_to_closest:
+            snap_cursor_to_closest_selected(filtered_verts)
             return
 
-        VertsDictForLine(uv_layer, bm, vertsDict)
+        verts_dict_for_line(uv_layer, bm, verts_dict)
 
-        if AreVectsLinedOnAxis(filteredVerts) is False:
-            ScaleTo0OnAxisAndCursor(filteredVerts, cursorClosestTo)
-            return SuccessFinished(me, startTime)
+        if are_vects_lined_on_axis(filtered_verts) is False:
+            scale_to_zero_on_axis_and_cursor(filtered_verts, cursor_closest_to)
+            return success_finished(me, start_time)
 
-        MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, cursorClosestTo)
-        return SuccessFinished(me, startTime)
+        make_equal_distance_between_verts_in_line(filtered_verts, verts_dict, cursor_closest_to)
+        return success_finished(me, start_time)
 
     # deselect non quads
-    for nf in nonQuadFaces:
+    for nf in non_quad_faces:
         for l in nf.loops:
             luv = l[uv_layer]
             luv.select = False
 
-    def isFaceSelected(f):
+    def is_face_selected(f):
         return f.select and all(l[uv_layer].select for l in f.loops)
 
-    def getIslandFromFace(startFace):
+    def get_island_from_face(start_face):
         island = set()
-        toCheck = set([startFace])
+        to_check = set([start_face])
 
-        while (len(toCheck)):
-            face = toCheck.pop()
-            if isFaceSelected(face) and face not in island:
+        while (len(to_check)):
+            face = to_check.pop()
+            if is_face_selected(face) and face not in island:
                 island.add(face)
-                adjacentFaces = []
+                adjacent_faces = []
                 for e in face.edges:
                     if e.seam is False:
                         for f in e.link_faces:
                             if f is not face:
-                                adjacentFaces.append(f)
-                toCheck.update(adjacentFaces)
+                                adjacent_faces.append(f)
+                to_check.update(adjacent_faces)
 
         return island
 
-    def getIslandsFromSelectedFaces(selectedFaces):
+    def get_islands_from_selected_faces(selected_faces):
         islands = []
-        toCheck = set(selectedFaces)
-        while (len(toCheck)):
-            face = toCheck.pop()
-            island = getIslandFromFace(face)
+        to_check = set(selected_faces)
+        while len(to_check):
+            face = to_check.pop()
+            island = get_island_from_face(face)
             islands.append(island)
-            toCheck.difference_update(island)
+            to_check.difference_update(island)
         return islands
 
-    islands = getIslandsFromSelectedFaces(selFaces)
+    islands = get_islands_from_selected_faces(sel_faces)
 
-    def main2(targetFace, faces):
-        ShapeFace(uv_layer, operator, targetFace, vertsDict, square)
+    def main2(target_face, faces):
+        shape_face(uv_layer, operator, target_face, verts_dict, square)
 
         if square:
-            FollowActiveUV(operator, me, targetFace, faces, 'EVEN')
+            follow_active_uv(operator, me, target_face, faces, 'EVEN')
         else:
-            FollowActiveUV(operator, me, targetFace, faces)
+            follow_active_uv(operator, me, target_face, faces)
 
     for island in islands:
-        targetFace = bm.faces.active
-        if (targetFace is None or
-                targetFace not in island or
+        target_face = bm.faces.active
+        if (target_face is None or
+                target_face not in island or
                 len(islands) > 1 or
-                not targetFace.select or
-                len(targetFace.verts) != 4):
-            targetFace = next(iter(island))
+                not target_face.select or
+                len(target_face.verts) != 4):
+            target_face = next(iter(island))
 
-        main2(targetFace, island)
+        main2(target_face, island)
 
-    if noEdge is False:
+    if no_edge is False:
         # edge has ripped so we connect it back
-        for ev in edgeVerts:
+        for ev in edge_verts:
             key = (round(ev.uv.x, precision), round(ev.uv.y, precision))
-            if key in vertsDict:
-                ev.uv = vertsDict[key][0].uv
+            if key in verts_dict:
+                ev.uv = verts_dict[key][0].uv
                 ev.select = True
 
-    return SuccessFinished(me, startTime)
+    return success_finished(me, start_time)
 
 
 '''def ScaleSelection(factor, pivot = 'CURSOR'):
@@ -166,9 +166,9 @@ def main1(obj, context, operator, square, snapToClosest):
     return'''
 
 
-def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
+def shape_face(uv_layer, operator, target_face, verts_dict, square):
     corners = []
-    for l in targetFace.loops:
+    for l in target_face.loops:
         luv = l[uv_layer]
         corners.append(luv)
 
@@ -176,23 +176,23 @@ def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
         # operator.report({'ERROR'}, "bla")
         return
 
-    lucv, ldcv, rucv, rdcv = Corners(corners)
+    lucv, ldcv, rucv, rdcv = find_corners(corners)
 
-    cct = CursorClosestTo([lucv, ldcv, rdcv, rucv])
-    MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, cct, square)
+    cct = find_cursor_closest_to([lucv, ldcv, rdcv, rucv])
+    make_uv_face_equal_rectangle(verts_dict, lucv, rucv, rdcv, ldcv, cct, square)
 
 
-def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square=False):
-    sizeX, sizeY = ImageSize()
-    ratio = sizeX / sizeY
+def make_uv_face_equal_rectangle(verts_dict, lucv, rucv, rdcv, ldcv, startv, square=False):
+    size_x, size_y = image_size()
+    ratio = size_x / size_y
 
     if startv is None:
         startv = lucv.uv
-    elif AreVertsQuasiEqual(startv, rucv):
+    elif are_verts_quasi_equal(startv, rucv):
         startv = rucv.uv
-    elif AreVertsQuasiEqual(startv, rdcv):
+    elif are_verts_quasi_equal(startv, rdcv):
         startv = rdcv.uv
-    elif AreVertsQuasiEqual(startv, ldcv):
+    elif are_verts_quasi_equal(startv, ldcv):
         startv = ldcv.uv
     else:
         startv = lucv.uv
@@ -202,127 +202,127 @@ def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square=F
     rdcv = rdcv.uv
     ldcv = ldcv.uv
 
-    if (startv == lucv):
-        finalScaleX = hypotVert(lucv, rucv)
-        finalScaleY = hypotVert(lucv, ldcv)
-        currRowX = lucv.x
-        currRowY = lucv.y
+    if startv == lucv:
+        final_scale_x = hypot_vert(lucv, rucv)
+        final_scale_y = hypot_vert(lucv, ldcv)
+        curr_row_x = lucv.x
+        curr_row_y = lucv.y
 
-    elif (startv == rucv):
-        finalScaleX = hypotVert(rucv, lucv)
-        finalScaleY = hypotVert(rucv, rdcv)
-        currRowX = rucv.x - finalScaleX
-        currRowY = rucv.y
+    elif startv == rucv:
+        final_scale_x = hypot_vert(rucv, lucv)
+        final_scale_y = hypot_vert(rucv, rdcv)
+        curr_row_x = rucv.x - final_scale_x
+        curr_row_y = rucv.y
 
-    elif (startv == rdcv):
-        finalScaleX = hypotVert(rdcv, ldcv)
-        finalScaleY = hypotVert(rdcv, rucv)
-        currRowX = rdcv.x - finalScaleX
-        currRowY = rdcv.y + finalScaleY
+    elif startv == rdcv:
+        final_scale_x = hypot_vert(rdcv, ldcv)
+        final_scale_y = hypot_vert(rdcv, rucv)
+        curr_row_x = rdcv.x - final_scale_x
+        curr_row_y = rdcv.y + final_scale_y
 
     else:
-        finalScaleX = hypotVert(ldcv, rdcv)
-        finalScaleY = hypotVert(ldcv, lucv)
-        currRowX = ldcv.x
-        currRowY = ldcv.y + finalScaleY
+        final_scale_x = hypot_vert(ldcv, rdcv)
+        final_scale_y = hypot_vert(ldcv, lucv)
+        curr_row_x = ldcv.x
+        curr_row_y = ldcv.y + final_scale_y
 
-    if square: finalScaleY = finalScaleX * ratio
+    if square: final_scale_y = final_scale_x * ratio
     # lucv, rucv
     x = round(lucv.x, precision)
     y = round(lucv.y, precision)
-    for v in vertsDict[(x, y)]:
-        v.uv.x = currRowX
-        v.uv.y = currRowY
+    for v in verts_dict[(x, y)]:
+        v.uv.x = curr_row_x
+        v.uv.y = curr_row_y
 
     x = round(rucv.x, precision)
     y = round(rucv.y, precision)
-    for v in vertsDict[(x, y)]:
-        v.uv.x = currRowX + finalScaleX
-        v.uv.y = currRowY
+    for v in verts_dict[(x, y)]:
+        v.uv.x = curr_row_x + final_scale_x
+        v.uv.y = curr_row_y
 
     # rdcv, ldcv
     x = round(rdcv.x, precision)
     y = round(rdcv.y, precision)
-    for v in vertsDict[(x, y)]:
-        v.uv.x = currRowX + finalScaleX
-        v.uv.y = currRowY - finalScaleY
+    for v in verts_dict[(x, y)]:
+        v.uv.x = curr_row_x + final_scale_x
+        v.uv.y = curr_row_y - final_scale_y
 
     x = round(ldcv.x, precision)
     y = round(ldcv.y, precision)
-    for v in vertsDict[(x, y)]:
-        v.uv.x = currRowX
-        v.uv.y = currRowY - finalScaleY
+    for v in verts_dict[(x, y)]:
+        v.uv.x = curr_row_x
+        v.uv.y = curr_row_y - final_scale_y
 
 
-def SnapCursorToClosestSelected(filteredVerts):
+def snap_cursor_to_closest_selected(filtered_verts):
     # TODO: snap to closest selected
-    if len(filteredVerts) == 1:
-        SetAll2dCursorsTo(filteredVerts[0].uv.x, filteredVerts[0].uv.y)
+    if len(filtered_verts) == 1:
+        set_all_2d_cursors_to(filtered_verts[0].uv.x, filtered_verts[0].uv.y)
 
 
-def ListsOfVerts(uv_layer, bm):
-    edgeVerts = []
-    allEdgeVerts = []
-    filteredVerts = []
-    selFaces = []
-    nonQuadFaces = []
-    vertsDict = defaultdict(list)  # dict
+def lists_of_verts(uv_layer, bm):
+    edge_verts = []
+    all_edge_verts = []
+    filtered_verts = []
+    sel_faces = []
+    non_quad_faces = []
+    verts_dict = defaultdict(list)  # dict
 
     for f in bm.faces:
-        isFaceSel = True
-        facesEdgeVerts = []
-        if (f.select == False):
+        is_face_sel = True
+        faces_edge_verts = []
+        if not f.select:
             continue
 
         # collect edge verts if any
         for l in f.loops:
             luv = l[uv_layer]
             if luv.select is True:
-                facesEdgeVerts.append(luv)
+                faces_edge_verts.append(luv)
             else:
-                isFaceSel = False
+                is_face_sel = False
 
-        allEdgeVerts.extend(facesEdgeVerts)
-        if isFaceSel:
+        all_edge_verts.extend(faces_edge_verts)
+        if is_face_sel:
             if len(f.verts) != 4:
-                nonQuadFaces.append(f)
-                edgeVerts.extend(facesEdgeVerts)
+                non_quad_faces.append(f)
+                edge_verts.extend(faces_edge_verts)
             else:
-                selFaces.append(f)
+                sel_faces.append(f)
 
                 for l in f.loops:
                     luv = l[uv_layer]
                     x = round(luv.uv.x, precision)
                     y = round(luv.uv.y, precision)
-                    vertsDict[(x, y)].append(luv)
+                    verts_dict[(x, y)].append(luv)
 
         else:
-            edgeVerts.extend(facesEdgeVerts)
+            edge_verts.extend(faces_edge_verts)
 
-    noEdge = False
-    if len(edgeVerts) == 0:
-        noEdge = True
-        edgeVerts.extend(allEdgeVerts)
+    no_edge = False
+    if len(edge_verts) == 0:
+        no_edge = True
+        edge_verts.extend(all_edge_verts)
 
-    if len(selFaces) == 0:
-        for ev in edgeVerts:
-            if ListQuasiContainsVect(filteredVerts, ev) is False:
-                filteredVerts.append(ev)
+    if len(sel_faces) == 0:
+        for ev in edge_verts:
+            if list_quasi_contains_vect(filtered_verts, ev) is False:
+                filtered_verts.append(ev)
     else:
-        filteredVerts = edgeVerts
+        filtered_verts = edge_verts
 
-    return edgeVerts, filteredVerts, selFaces, nonQuadFaces, vertsDict, noEdge
+    return edge_verts, filtered_verts, sel_faces, non_quad_faces, verts_dict, no_edge
 
 
-def ListQuasiContainsVect(list, vect):
+def list_quasi_contains_vect(list, vect):
     for v in list:
-        if AreVertsQuasiEqual(v, vect):
+        if are_verts_quasi_equal(v, vect):
             return True
     return False
 
 
 # modified ideasman42's uvcalc_follow_active.py
-def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE='LENGTH_AVERAGE'):
+def follow_active_uv(operator, me, f_act, faces, extend_mode='LENGTH_AVERAGE'):
     bm = bmesh.from_edit_mesh(me)
     uv_act = bm.loops.layers.uv.active
 
@@ -427,12 +427,12 @@ def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE='LENGTH_AVERAGE'):
         l_a_uv = [l[uv_act].uv for l in l_a]
         l_b_uv = [l[uv_act].uv for l in l_b]
 
-        if EXTEND_MODE == 'LENGTH_AVERAGE':
+        if extend_mode == 'LENGTH_AVERAGE':
             try:
                 fac = edge_lengths[l_b[2].edge.index][0] / edge_lengths[l_a[1].edge.index][0]
             except ZeroDivisionError:
                 fac = 1.0
-        elif EXTEND_MODE == 'LENGTH':
+        elif extend_mode == 'LENGTH':
             a0, b0, c0 = l_a[3].vert.co, l_a[0].vert.co, l_b[3].vert.co
             a1, b1, c1 = l_a[2].vert.co, l_a[1].vert.co, l_b[2].vert.co
 
@@ -456,7 +456,7 @@ def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE='LENGTH_AVERAGE'):
     # -------------------------------------------
     # Calculate average length per loop if needed
 
-    if EXTEND_MODE == 'LENGTH_AVERAGE':
+    if extend_mode == 'LENGTH_AVERAGE':
         bm.edges.index_update()
         edge_lengths = [None] * len(bm.edges)  # NoneType times the length of edges list
 
@@ -496,11 +496,11 @@ def FollowActiveUV(operator, me, f_act, faces, EXTEND_MODE='LENGTH_AVERAGE'):
 '''----------------------------------'''
 
 
-def SuccessFinished(me, startTime):
+def success_finished(me, start_time):
     # use for backtrack of steps
     # bpy.ops.ed.undo_push()
     bmesh.update_edit_mesh(me)
-    elapsed = round(timer() - startTime, 2)
+    elapsed = round(timer() - start_time, 2)
     # if (elapsed >= 0.05): operator.report({'INFO'}, "UvSquares finished, elapsed:", elapsed, "s.")
     if elapsed >= 0.05:
         print("UvSquares finished, elapsed:", elapsed, "s.")
@@ -514,22 +514,22 @@ def SuccessFinished(me, startTime):
     return'''
 
 
-def AreVectsLinedOnAxis(verts):
-    areLinedX = True
-    areLinedY = True
-    allowedError = 0.00001
-    valX = verts[0].uv.x
-    valY = verts[0].uv.y
+def are_vects_lined_on_axis(verts):
+    are_lined_x = True
+    are_lined_y = True
+    allowed_error = 0.00001
+    val_x = verts[0].uv.x
+    val_y = verts[0].uv.y
     for v in verts:
-        if abs(valX - v.uv.x) > allowedError:
-            areLinedX = False
-        if abs(valY - v.uv.y) > allowedError:
-            areLinedY = False
-    return areLinedX or areLinedY
+        if abs(val_x - v.uv.x) > allowed_error:
+            are_lined_x = False
+        if abs(val_y - v.uv.y) > allowed_error:
+            are_lined_y = False
+    return are_lined_x or are_lined_y
 
 
-def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv=None):
-    verts = filteredVerts
+def make_equal_distance_between_verts_in_line(filtered_verts, verts_dict, startv=None):
+    verts = filtered_verts
     verts.sort(key=lambda x: x.uv[0])  # sort by .x
 
     first = verts[0].uv
@@ -547,11 +547,11 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv=None):
         length = hypot(first.x - last.x, first.y - last.y)
 
         if startv is last:
-            currentX = last.x - length
-            currentY = last.y
+            current_x = last.x - length
+            current_y = last.y
         else:
-            currentX = first.x
-            currentY = first.y
+            current_x = first.x
+            current_y = first.y
     else:
         verts.sort(key=lambda x: x.uv[1])  # sort by .y
         verts.reverse()  # reverse because y values drop from up to down
@@ -562,15 +562,15 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv=None):
                        first.y - last.y)  # we have to call length here because if it is not Hor first and second can not actually be first and second
 
         if startv is last:
-            currentX = last.x
-            currentY = last.y + length
+            current_x = last.x
+            current_y = last.y + length
 
         else:
-            currentX = first.x
-            currentY = first.y
+            current_x = first.x
+            current_y = first.y
 
-    numberOfVerts = len(verts)
-    finalScale = length / (numberOfVerts - 1)
+    number_of_verts = len(verts)
+    final_scale = length / (number_of_verts - 1)
 
     if horizontal is True:
         for v in verts:
@@ -578,24 +578,24 @@ def MakeEqualDistanceBetweenVertsInLine(filteredVerts, vertsDict, startv=None):
             x = round(v.x, precision)
             y = round(v.y, precision)
 
-            for vert in vertsDict[(x, y)]:
-                vert.uv.x = currentX
-                vert.uv.y = currentY
+            for vert in verts_dict[(x, y)]:
+                vert.uv.x = current_x
+                vert.uv.y = current_y
 
-            currentX = currentX + finalScale
+            current_x = current_x + final_scale
     else:
         for v in verts:
             x = round(v.uv.x, precision)
             y = round(v.uv.y, precision)
 
-            for vert in vertsDict[(x, y)]:
-                vert.uv.x = currentX
-                vert.uv.y = currentY
+            for vert in verts_dict[(x, y)]:
+                vert.uv.x = current_x
+                vert.uv.y = current_y
 
-            currentY = currentY - finalScale
+            current_y = current_y - final_scale
 
 
-def VertsDictForLine(uv_layer, bm, vertsDict):
+def verts_dict_for_line(uv_layer, bm, verts_dict):
     for f in bm.faces:
         for l in f.loops:
             luv = l[uv_layer]
@@ -603,11 +603,11 @@ def VertsDictForLine(uv_layer, bm, vertsDict):
                 x = round(luv.uv.x, precision)
                 y = round(luv.uv.y, precision)
 
-                vertsDict[(x, y)].append(luv)
+                verts_dict[(x, y)].append(luv)
 
 
-def ScaleTo0OnAxisAndCursor(filteredVerts, startv=None, horizontal=None):
-    verts = filteredVerts
+def scale_to_zero_on_axis_and_cursor(filtered_verts, startv=None, horizontal=None):
+    verts = filtered_verts
     verts.sort(key=lambda x: x.uv[0])  # sort by .x
 
     first = verts[0]
@@ -615,7 +615,7 @@ def ScaleTo0OnAxisAndCursor(filteredVerts, startv=None, horizontal=None):
 
     if horizontal is None:
         horizontal = True
-        if ((last.uv.x - first.uv.x) > 0.00001):
+        if (last.uv.x - first.uv.x) > 0.00001:
             slope = (last.uv.y - first.uv.y) / (last.uv.x - first.uv.x)
             if (slope > 1) or (slope < -1):
                 horizontal = False
@@ -626,9 +626,9 @@ def ScaleTo0OnAxisAndCursor(filteredVerts, startv=None, horizontal=None):
         if startv is None:
             startv = first
 
-        SetAll2dCursorsTo(startv.uv.x, startv.uv.y)
+        set_all_2d_cursors_to(startv.uv.x, startv.uv.y)
         # scale to 0 on Y
-        ScaleTo0('Y')
+        scale_to_zero('Y')
 
     else:
         verts.sort(key=lambda x: x.uv[1])  # sort by .y
@@ -638,12 +638,12 @@ def ScaleTo0OnAxisAndCursor(filteredVerts, startv=None, horizontal=None):
         if startv is None:
             startv = first
 
-        SetAll2dCursorsTo(startv.uv.x, startv.uv.y)
+        set_all_2d_cursors_to(startv.uv.x, startv.uv.y)
         # scale to 0 on X
-        ScaleTo0('X')
+        scale_to_zero('X')
 
 
-def ScaleTo0(axis):
+def scale_to_zero(axis):
     last_area = bpy.context.area.type
     bpy.context.area.type = 'IMAGE_EDITOR'
     last_pivot = bpy.context.space_data.pivot_point
@@ -661,81 +661,80 @@ def ScaleTo0(axis):
     bpy.context.space_data.pivot_point = last_pivot
 
 
-def hypotVert(v1, v2):
+def hypot_vert(v1, v2):
     hyp = hypot(v1.x - v2.x, v1.y - v2.y)
     return hyp
 
 
-def Corners(corners):
-    firstHighest = corners[0]
+def find_corners(corners):
+    first_highest = corners[0]
     for c in corners:
-        if c.uv.y > firstHighest.uv.y:
-            firstHighest = c
-    corners.remove(firstHighest)
+        if c.uv.y > first_highest.uv.y:
+            first_highest = c
+    corners.remove(first_highest)
 
-    secondHighest = corners[0]
+    second_highest = corners[0]
     for c in corners:
-        if (c.uv.y > secondHighest.uv.y):
-            secondHighest = c
+        if c.uv.y > second_highest.uv.y:
+            second_highest = c
 
-    if firstHighest.uv.x < secondHighest.uv.x:
-        leftUp = firstHighest
-        rightUp = secondHighest
+    if first_highest.uv.x < second_highest.uv.x:
+        left_up = first_highest
+        right_up = second_highest
     else:
-        leftUp = secondHighest
-        rightUp = firstHighest
-    corners.remove(secondHighest)
+        left_up = second_highest
+        right_up = first_highest
+    corners.remove(second_highest)
 
-    firstLowest = corners[0]
-    secondLowest = corners[1]
+    first_lowest = corners[0]
+    second_lowest = corners[1]
 
-    if firstLowest.uv.x < secondLowest.uv.x:
-        leftDown = firstLowest
-        rightDown = secondLowest
+    if first_lowest.uv.x < second_lowest.uv.x:
+        left_down = first_lowest
+        right_down = second_lowest
     else:
-        leftDown = secondLowest
-        rightDown = firstLowest
+        left_down = second_lowest
+        right_down = first_lowest
 
-    return leftUp, leftDown, rightUp, rightDown
+    return left_up, left_down, right_up, right_down
 
 
-def ImageSize():
-    ratioX, ratioY = 256, 256
+def image_size():
+    ratio_x, ratio_y = 256, 256
     for a in bpy.context.screen.areas:
         if a.type == 'IMAGE_EDITOR':
             img = a.spaces[0].image
             if img is not None and img.size[0] != 0:
-                ratioX, ratioY = img.size[0], img.size[1]
+                ratio_x, ratio_y = img.size[0], img.size[1]
             break
-    return ratioX, ratioY
+    return ratio_x, ratio_y
 
 
-def CursorClosestTo(verts):
-    sizeX, sizeY = ImageSize()
+def find_cursor_closest_to(verts):
+    size_x, size_y = image_size()
     if bpy.app.version >= (2, 80, 0):
-        sizeX, sizeY = 1, 1
-    min = float('inf')
-    minV = verts[0]
+        size_x, size_y = 1, 1
+    curr_min = float('inf')
+    min_v = verts[0]
     for v in verts:
         if v is None: continue
         for area in bpy.context.screen.areas:
             if area.type == 'IMAGE_EDITOR':
                 loc = area.spaces[0].cursor_location
-                hyp = hypot(loc.x / sizeX - v.uv.x, loc.y / sizeY - v.uv.y)
-                if (hyp < min):
-                    min = hyp
-                    minV = v
-    return minV
+                hyp = hypot(loc.x / size_x - v.uv.x, loc.y / size_y - v.uv.y)
+                if (hyp < curr_min):
+                    curr_min = hyp
+                    min_v = v
+    return min_v
 
 
-def SetAll2dCursorsTo(x, y):
+def set_all_2d_cursors_to(x, y):
     last_area = bpy.context.area.type
     bpy.context.area.type = 'IMAGE_EDITOR'
 
     bpy.ops.uv.cursor_set(location=(x, y))
 
     bpy.context.area.type = last_area
-    return
 
 
 '''def RotateSelected(angle, pivot = None):
@@ -759,14 +758,14 @@ def SetAll2dCursorsTo(x, y):
     return'''
 
 
-def AreVertsQuasiEqual(v1, v2, allowedError=0.00001):
-    if abs(v1.uv.x - v2.uv.x) < allowedError and abs(v1.uv.y - v2.uv.y) < allowedError:
+def are_verts_quasi_equal(v1, v2, allowed_error=0.00001):
+    if abs(v1.uv.x - v2.uv.x) < allowed_error and abs(v1.uv.y - v2.uv.y) < allowed_error:
         return True
     return False
 
 
-def RipUvFaces(context, operator):
-    startTime = timer()
+def rip_uv_faces(context, operator):
+    start_time = timer()
 
     obj = context.active_object
     me = obj.data
@@ -775,20 +774,20 @@ def RipUvFaces(context, operator):
     uv_layer = bm.loops.layers.uv.verify()
     # bm.faces.layers.tex.verify()  # currently blender needs both layers.
 
-    selFaces = []
+    sel_faces = []
 
     for f in bm.faces:
-        isFaceSel = True
+        is_face_sel = True
         for l in f.loops:
             luv = l[uv_layer]
             if luv.select is False:
-                isFaceSel = False
+                is_face_sel = False
                 break
 
-        if isFaceSel is True:
-            selFaces.append(f)
+        if is_face_sel is True:
+            sel_faces.append(f)
 
-    if len(selFaces) == 0:
+    if len(sel_faces) == 0:
         target = None
         for f in bm.faces:
             for l in f.loops:
@@ -804,20 +803,20 @@ def RipUvFaces(context, operator):
                 luv.select = False
 
         target.select = True
-        return SuccessFinished(me, startTime)
+        return success_finished(me, start_time)
 
-    DeselectAll()
+    deselect_all()
 
-    for sf in selFaces:
+    for sf in sel_faces:
         for l in sf.loops:
             luv = l[uv_layer]
             luv.select = True
 
-    return SuccessFinished(me, startTime)
+    return success_finished(me, start_time)
 
 
-def JoinUvFaces(context):
-    startTime = timer()
+def join_uv_faces(context):
+    start_time = timer()
 
     obj = context.active_object
     me = obj.data
@@ -826,7 +825,7 @@ def JoinUvFaces(context):
     uv_layer = bm.loops.layers.uv.verify()
     # bm.faces.layers.tex.verify()  # currently blender needs both layers.
 
-    vertsDict = defaultdict(list)  # dict
+    verts_dict = defaultdict(list)  # dict
 
     # TODO: radius by image scale
     radius = 0.002
@@ -837,35 +836,34 @@ def JoinUvFaces(context):
             if luv.select is True:
                 x = round(luv.uv.x, precision)
                 y = round(luv.uv.y, precision)
-                vertsDict[(x, y)].append(luv)
+                verts_dict[(x, y)].append(luv)
 
-    for key in vertsDict:
-        min = 1
-        minV = None
+    for key in verts_dict:
+        curr_min = 1
+        min_v = None
 
         for f in bm.faces:
             for l in f.loops:
                 luv = l[uv_layer]
                 if luv.select is False:
-                    hyp = hypot(vertsDict[(key[0], key[1])][0].uv.x - luv.uv.x,
-                                vertsDict[(key[0], key[1])][0].uv.y - luv.uv.y)
-                    if (hyp <= min) and hyp < radius:
-                        min = hyp
-                        minV = luv
-                        minV.select = True
+                    hyp = hypot(verts_dict[(key[0], key[1])][0].uv.x - luv.uv.x,
+                                verts_dict[(key[0], key[1])][0].uv.y - luv.uv.y)
+                    if (hyp <= curr_min) and hyp < radius:
+                        curr_min = hyp
+                        min_v = luv
+                        min_v.select = True
 
-            if min != 1:
-                for v in vertsDict[(key[0], key[1])]:
+            if curr_min != 1:
+                for v in verts_dict[(key[0], key[1])]:
                     v = v.uv
-                    v.x = minV.uv.x
-                    v.y = minV.uv.y
+                    v.x = min_v.uv.x
+                    v.y = min_v.uv.y
 
-    return SuccessFinished(me, startTime)
+    return success_finished(me, start_time)
 
 
-def DeselectAll():
+def deselect_all():
     bpy.ops.uv.select_all(action='DESELECT')
-    return
 
 
 class UV_PT_UvSquares(bpy.types.Operator):
@@ -909,7 +907,7 @@ class UV_PT_RipFaces(bpy.types.Operator):
         return (context.mode == 'EDIT_MESH')
 
     def execute(self, context):
-        RipUvFaces(context, self)
+        rip_uv_faces(context, self)
         return {'FINISHED'}
 
 
@@ -924,7 +922,7 @@ class UV_PT_JoinFaces(bpy.types.Operator):
         return (context.mode == 'EDIT_MESH')
 
     def execute(self, context):
-        JoinUvFaces(context)
+        join_uv_faces(context)
         return {'FINISHED'}
 
 

--- a/uv_squares.py
+++ b/uv_squares.py
@@ -65,16 +65,16 @@ def main1(obj, context, operator, square, snapToClosest):
 
     edgeVerts, filteredVerts, selFaces, nonQuadFaces, vertsDict, noEdge = ListsOfVerts(uv_layer, bm)
     
-    if len(filteredVerts) is 0: return 
-    if len(filteredVerts) is 1: 
+    if len(filteredVerts) == 0: return
+    if len(filteredVerts) == 1:
         SnapCursorToClosestSelected(filteredVerts)
         return 
     
     cursorClosestTo = CursorClosestTo(filteredVerts)
     #line is selected
     
-    if len(selFaces) is 0:
-        if snapToClosest is True:
+    if len(selFaces) == 0:
+        if snapToClosest:
             SnapCursorToClosestSelected(filteredVerts)
             return
         
@@ -137,8 +137,8 @@ def main1(obj, context, operator, square, snapToClosest):
         if (targetFace is None or
             targetFace not in island or
             len(islands) > 1 or
-            targetFace.select is False or
-            len(targetFace.verts) is not 4):
+            not targetFace.select or
+            len(targetFace.verts) != 4):
                 targetFace = next(iter(island))
         
         main2(targetFace, island)
@@ -166,7 +166,7 @@ def ShapeFace(uv_layer, operator, targetFace, vertsDict, square):
         luv = l[uv_layer]
         corners.append(luv)
     
-    if len(corners) is not 4: 
+    if len(corners) != 4:
         #operator.report({'ERROR'}, "bla")
         return
     
@@ -247,7 +247,7 @@ def MakeUvFaceEqualRectangle(vertsDict, lucv, rucv, rdcv, ldcv, startv, square =
 
 def SnapCursorToClosestSelected(filteredVerts):
     #TODO: snap to closest selected 
-    if len(filteredVerts) is 1: 
+    if len(filteredVerts) == 1:
         SetAll2dCursorsTo(filteredVerts[0].uv.x, filteredVerts[0].uv.y)
     
     return
@@ -275,7 +275,7 @@ def ListsOfVerts(uv_layer, bm):
         
         allEdgeVerts.extend(facesEdgeVerts)
         if isFaceSel:            
-            if len(f.verts) is not 4:
+            if len(f.verts) != 4:
                 nonQuadFaces.append(f)
                 edgeVerts.extend(facesEdgeVerts)
             else: 
@@ -290,11 +290,11 @@ def ListsOfVerts(uv_layer, bm):
         else: edgeVerts.extend(facesEdgeVerts)
     
     noEdge = False
-    if len(edgeVerts) is 0:
+    if len(edgeVerts) == 0:
         noEdge = True
         edgeVerts.extend(allEdgeVerts)
     
-    if len(selFaces) is 0:
+    if len(selFaces) == 0:
         for ev in edgeVerts:
             if ListQuasiContainsVect(filteredVerts, ev) is False:
                 filteredVerts.append(ev)
@@ -637,7 +637,7 @@ def ScaleTo0(axis):
     
     for area in bpy.context.screen.areas:
         if area.type == 'IMAGE_EDITOR':
-            if axis is 'Y':
+            if axis == 'Y':
                 bpy.ops.transform.resize(value=(1, 0, 1), constraint_axis=(False, True, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
             else:
                 bpy.ops.transform.resize(value=(0, 1, 1), constraint_axis=(True, False, False), mirror=False, proportional_edit_falloff='SMOOTH', proportional_size=1)
@@ -688,7 +688,7 @@ def ImageSize():
     for a in bpy.context.screen.areas:
         if a.type == 'IMAGE_EDITOR':
             img = a.spaces[0].image
-            if img is not None and img.size[0] is not 0:
+            if img is not None and img.size[0] != 0:
                 ratioX, ratioY = img.size[0], img.size[1]
             break
     return ratioX, ratioY
@@ -767,7 +767,7 @@ def RipUvFaces(context, operator):
         if isFaceSel is True:
             selFaces.append(f)
     
-    if len(selFaces) is 0:
+    if len(selFaces) == 0:
         target = None
         for f in bm.faces:
             for l in f.loops:
@@ -831,7 +831,7 @@ def JoinUvFaces(context, operator):
                         minV = luv
                         minV.select = True
         
-            if min is not 1:
+            if min != 1:
                 for v in vertsDict[(key[0], key[1])]:
                     v = v.uv
                     v.x = minV.uv.x


### PR DESCRIPTION
No functionality changes. Various formatting refactors to make code more readable and friendly to future changes, including:

- Fix #37 for warnings in Blender regarding inversion and usage of `is` vs `==` in conditionals
- Basic reformatting of whitespace, including removing redundant parentheses
- Rename variables and functions to snake case to match standard conventions
- Add .gitignore for future contributors :)